### PR TITLE
docker build command fix

### DIFF
--- a/实验任务书.ipynb
+++ b/实验任务书.ipynb
@@ -254,7 +254,7 @@
    ],
    "source": [
     "%cd typilus/src/data_preparation/\n",
-    "!docker build -t typilus-env"
+    "!docker build -t typilus-env ."
    ]
   },
   {


### PR DESCRIPTION
`docker build`那句没加路径 在Ubuntu直接跑会报错